### PR TITLE
Allow failures for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
 notifications:
   email: false
@@ -15,9 +17,9 @@ git:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
+matrix:
+ allow_failures:
+ - julia: nightly
 
 ## uncomment following lines to deploy documentation
 # jobs:


### PR DESCRIPTION
Hi, and thanks for `PkgSkeleton.jl`.

This PR modifies the travis configuration so that tests are allowed to fail with nightly builds of julia, which I've noticed are currently broken. While I was at it, I also added more julia versions.

Regarding the failure with nightly builds:
1. `Pkg.METADATA_compatible_uuid` has been dropped, which makes the package generation fail, but fortunately
2. it looks like there is no need for this anymore: any UUID should be fine.

Do you know whether I'm correct in saying this, and don't you think this problem should be fixed so that `PkgSkeleton` does not break when v1.3 is released? If so, I'm willing to open an other PR (or add to this one) in order to fix this...