### PR TITLE
Get rid of Pkg.METADATA_compatible_uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -8,14 +8,14 @@ ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "^1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "UUIDs"]
+test = ["Test", "Pkg"]

--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -7,7 +7,7 @@ using ArgCheck: @argcheck
 import Dates
 using DocStringExtensions: SIGNATURES
 import LibGit2
-import Pkg
+import UUIDs
 
 ####
 ####
@@ -27,7 +27,7 @@ and state.
 function get_replacement_values(; pkg_name)
     c = LibGit2.GitConfig()     # global configuration
     _getgitopt(opt, type = AbstractString) = LibGit2.get(type, c, opt)
-    ["{UUID}" => Pkg.METADATA_compatible_uuid(pkg_name),
+    ["{UUID}" => UUIDs.uuid4(),
      "{PKGNAME}" => pkg_name,
      "{GHUSER}" => _getgitopt("github.user"),
      "{USERNAME}" => _getgitopt("user.name"),


### PR DESCRIPTION
As an alternative to #6, this PR gets rid of `Pkg.METADATA_compatible_uuid`, which fixes the tests for all Julia versions, including the current nightly where this function disappeared from `Pkg`.

(like in #6, I also took the opportunity to update the tested Julia versions list)