### PR TITLE
bump documenter versions

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -19,9 +19,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "4d30e889c9f106a51ffa4791a88ffd4765bf20c3"
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.7.0"
+version = "0.8.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -29,6 +29,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -38,7 +41,7 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/templates/default/docs/Project.toml
+++ b/templates/default/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.22"
+Documenter = "~0.23.4"

--- a/templates/default/docs/make.jl
+++ b/templates/default/docs/make.jl
@@ -2,10 +2,13 @@ using Documenter, {PKGNAME}
 
 makedocs(
     modules = [{PKGNAME}],
-    format = Documenter.HTML(),
-    checkdocs = :exports,
+    format = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true"),
+    authors = "{USERNAME}",
     sitename = "{PKGNAME}.jl",
     pages = Any["index.md"]
+    # strict = true,
+    # clean = true,
+    # checkdocs = :exports,
 )
 
 deploydocs(


### PR DESCRIPTION
Also refresh template a bit: test for CI environment, uncomment
optional (but useful) keyword arguments so that the user can enable
them on demand but they don't interfere if not needed.