### PR TITLE
Setup (instantiate) the docs project from the beginning

### DIFF
--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -192,8 +192,8 @@ function generate(dest_dir; template = :default,
     # docs manifest
     if docs_manifest
         @info "adding documenter (completing the Manifest.toml for docs)"
-        docs = joinpath(dest_dir, "docs")
-        run(`$(Base.julia_cmd()) --project=$(docs) -e 'import Pkg; Pkg.add("Documenter")'`)
+        docs_setup = joinpath(dest_dir, "docs", "setup.jl")
+        run(`$(Base.julia_cmd()) $(docs_setup)`)
     end
 
     # done

--- a/templates/default/docs/setup.jl
+++ b/templates/default/docs/setup.jl
@@ -1,0 +1,4 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.add("Documenter")
+Pkg.develop(PackageSpec(path=joinpath(@__DIR__, "..")))


### PR DESCRIPTION
In the current version of `PkgSkeleton.jl`, the user is expected to setup the documentation sub-project by running the following commands in the test subdirectory (more or less taken from the "test documentation (instantiation)" part of the test suite):
```julia
using Pkg
Pkg.activate(".")
Pkg.add("Documenter")
Pkg.develop(PackageSpec(path=joinpath("..")))
```
Only then is it possible to start generating the documentation.

The following PR does this during the package generation phase. It also puts these commands in a `docs/setup.jl` file, so that another user only has to clone the repository of the generated package and run the `docs/setup.jl` script before they can start generating the documentation.