### PR TITLE
Make the template values selection more interactive

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,15 @@ else
 end
 
 ####
+#### Mock _confirm_default since no user should be assumed to be in front of the keyboard.
+####
+
+function PkgSkeleton._confirm_default(prompt, default)
+    println("$prompt ($default)>")
+    default
+end
+
+####
 #### test components
 ####
 


### PR DESCRIPTION
This PR makes the selection of templates parameters more interactive. Git-config is used to retrieve default values, which are then interactively proposed to be validated (or amended) by the user. A final confirmation is asked before going on with the project configuration as usual.

```julia
julia> PkgSkeleton.generate("Foo")
[ Info: getting template values
Confirm default values by pressing RETURN, or enter a customized value
Author name (John Doe)>
Author email (johndoe@gmail.com)> john.doe@example.com
Github user name ()> jdoe
Copyright year (2019)> 
┌ Info: parameters:
│   {UUID} = UUID("1a7ac041-bdf1-4da1-9e3a-91f6f6c88e92")
│   {PKGNAME} = "Foo"
│   {USERNAME} = "John Doe"
│   {USEREMAIL} = "john.doe@example.com"
│   {GHUSER} = "jdoe"
└   {YEAR} = 2019
Confirm (Y)> 
[ Info: copy and substitute
...
```

My use case for this is that on my home computer, I can't set up a global git-config identity: depending on which project I work on, I use either my personal email address or my professional one.

I'm not sure this PR is entirely in line with what you had in mind, though. Please feel free to comment / criticize / reject it!

And, as always, thank you for your work on this!