### PR TITLE
dev the parent package in the doc project when generating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- dev the parent package in the docs project upon generation
+
 # 0.3.1
 
 - fix initial version in template

--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -193,7 +193,9 @@ function generate(dest_dir; template = :default,
     if docs_manifest
         @info "adding documenter (completing the Manifest.toml for docs)"
         docs = joinpath(dest_dir, "docs")
-        run(`$(Base.julia_cmd()) --project=$(docs) -e 'import Pkg; Pkg.add("Documenter")'`)
+        cd(docs) do
+            run(`$(Base.julia_cmd()) --project=$(docs) -e 'import Pkg; Pkg.add("Documenter"); Pkg.develop(Pkg.PackageSpec(; path = ".."))'`)
+        end
     end
 
     # done

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,7 +100,7 @@ end
         # run various sanity checks (mostly test contents of the template, CI will error)
         cd(dest_dir) do
             @info "test documentation (instantiation)"
-            run(`julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'`)
+            run(`julia --project=docs -e 'using Pkg; Pkg.instantiate()'`)
             @info "test documentation (generation)"
             run(`julia --project=docs --color=yes docs/make.jl`)
             @info "test coverage (only instantiation)"


### PR DESCRIPTION
Implements the suggestion in #11 without leaving a setup file around.