### PR TITLE
dont spawn new process for Pkg

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -28,6 +28,7 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,13 @@ ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "^1"
 ArgCheck = "^1"
 DocStringExtensions = "^0.8"
+julia = "^1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -201,7 +201,7 @@ function generate(dest_dir; template = :default,
                 Pkg.add("Documenter")
                 Pkg.develop(Pkg.PackageSpec(; path = ".."))
             finally
-                Base.ACTIVE_PROJECT[] = old
+                Base.active_project(current_project)
             end
         end
     end

--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -8,6 +8,7 @@ import Dates
 using DocStringExtensions: SIGNATURES
 import LibGit2
 import UUIDs
+import Pkg
 
 ####
 ####
@@ -194,7 +195,14 @@ function generate(dest_dir; template = :default,
         @info "adding documenter (completing the Manifest.toml for docs)"
         docs = joinpath(dest_dir, "docs")
         cd(docs) do
-            run(`$(Base.julia_cmd()) --project=$(docs) -e 'import Pkg; Pkg.add("Documenter"); Pkg.develop(Pkg.PackageSpec(; path = ".."))'`)
+            old = Base.ACTIVE_PROJECT[]
+            try
+                Pkg.activate(".")
+                Pkg.add("Documenter")
+                Pkg.develop(Pkg.PackageSpec(; path = ".."))
+            finally
+                Base.ACTIVE_PROJECT[] = old
+            end
         end
     end
 

--- a/src/PkgSkeleton.jl
+++ b/src/PkgSkeleton.jl
@@ -195,7 +195,7 @@ function generate(dest_dir; template = :default,
         @info "adding documenter (completing the Manifest.toml for docs)"
         docs = joinpath(dest_dir, "docs")
         cd(docs) do
-            old = Base.ACTIVE_PROJECT[]
+            current_project = Base.active_project()
             try
                 Pkg.activate(".")
                 Pkg.add("Documenter")


### PR DESCRIPTION
First, nice package! I appreciate the minimalism.

I noticed PkgSkeleton was slower than expected when generating multiple repos at once. This avoids the cost of spawning a new process and of unnecessary registry updates.