### PR TITLE
Add Documentation.yml GitHub action

### DIFF
--- a/templates/default/.github/workflows/Documentation.yml
+++ b/templates/default/.github/workflows/Documentation.yml
@@ -1,0 +1,23 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+        run: julia --project=docs/ docs/make.jl

--- a/templates/default/.github/workflows/Documentation.yml
+++ b/templates/default/.github/workflows/Documentation.yml
@@ -20,4 +20,5 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          #DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Hi Tamas, 

this way of building docs is much easier and cleaner than using travis,
the only caveat is:
https://github.com/JuliaDocs/Documenter.jl/issues/1177
TL;DR:
the user has to trigger for the first time a build on the docs via a no-op commit to gh-pages branch
it still seems much prettier than adding keys to the repo manually

and if manually triggering github to rebuild the pages is too much to bear, the user can still add the traditional DOCUMENTER_KEY environment variable

all in all this way of deploying docs to me it seems to be much smoother to new users

let me know what you think

Best regards,

Francesco