### PR TITLE
Add lookup functionality in the registry.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
@@ -17,6 +18,7 @@ ArgCheck = "1, 2"
 DocStringExtensions = "0.8"
 UnPack = "1"
 julia = "1"
+TOML = "1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
When an existing UUID cannot be found, an attempt is made to look one up in the registry.

This should make it easier to migrate pre-1.0 packages.